### PR TITLE
Fix compilation on GCC 4.9.2

### DIFF
--- a/makefile
+++ b/makefile
@@ -5,8 +5,8 @@
 # make YSF
 #
 
-GPP = g++ -m32 -Ilib -DSAMPGDK_AMALGAMATION -nodefaultlibs
-GCC = gcc -m32 -Ilib -DSAMPGDK_AMALGAMATION -nodefaultlibs
+GPP = g++ -m32 -Ilib -DSAMPGDK_AMALGAMATION -fno-stack-protector
+GCC = gcc -m32 -Ilib -DSAMPGDK_AMALGAMATION -fno-stack-protector
 YSF_OUTFILE = "./YSF.so"
 
 COMPILE_FLAGS = -c -O3 -fpack-struct=1 -fPIC -w -DLINUX
@@ -24,4 +24,4 @@ YSF: clean
 	$(GCC) $(YSF) ./lib/subhook/subhook.c
 	$(GCC) $(YSF) ./lib/sampgdk/sampgdk.c
 	$(GPP) $(YSF) ./src/*.cpp
-	$(GCC) -fshort-wchar -shared -o $(YSF_OUTFILE) *.o
+	$(GCC) -nodefaultlibs -fshort-wchar -shared -o $(YSF_OUTFILE) *.o

--- a/src/Hooks.cpp
+++ b/src/Hooks.cpp
@@ -369,7 +369,7 @@ static BYTE HOOK_GetPacketID(Packet *p)
 #ifdef _WIN32
 bool __thiscall CHookRakServer::Send(void* ppRakServer, RakNet::BitStream* parameters, PacketPriority priority, PacketReliability reliability, unsigned orderingChannel, PlayerID playerId, bool broadcast)
 #else
-bool CHookRakServer::Send(void* ppRakServer, RakNet::BitStream* parameters, int priority, int reliability, unsigned orderingChannel, PlayerID playerId, bool broadcast)
+bool CHookRakServer::Send(void* ppRakServer, RakNet::BitStream* parameters, PacketPriority priority, PacketReliability reliability, unsigned orderingChannel, PlayerID playerId, bool broadcast)
 #endif
 {
 /*


### PR DESCRIPTION
Fixes this:

```
g++ -m32 -Ilib -DSAMPGDK_AMALGAMATION -nodefaultlibs -D YSF -c -O3 -fpack-struct=1 -fPIC -w -DLINUX ./src/*.cpp
./src/Hooks.cpp:372:6: error: prototype for ‘bool CHookRakServer::Send(void*, RakNet::BitStream*, int, int, unsigned int, PlayerID, bool)’ does not match any in class ‘CHookRakServer’
 bool CHookRakServer::Send(void* ppRakServer, RakNet::BitStream* parameters, int priority, int reliability, unsigned orderingChannel, PlayerID playerId, bool broadcast)
      ^
./src/Hooks.cpp:61:14: error: candidate is: static bool CHookRakServer::Send(void*, RakNet::BitStream*, PacketPriority, PacketReliability, unsigned int, PlayerID, bool)
  static bool Send(void* ppRakServer, RakNet::BitStream* parameters, PacketPriority priority, PacketReliability reliability, unsigned orderingChannel, PlayerID playerId, bool broadcast);
              ^
makefile:22: recipe for target 'YSF' failed
make: *** [YSF] Error 1
```

```
gcc -m32 -Ilib -DSAMPGDK_AMALGAMATION -nodefaultlibs -fshort-wchar -shared -o "./YSF.so" *.o
CCallbackManager.o: In function `CCallbackManager::OnPlayerEnterGangZone(unsigned short, unsigned short)':
CCallbackManager.cpp:(.text+0x202): undefined reference to `__stack_chk_fail_local'
CCallbackManager.o: In function `CCallbackManager::OnPlayerLeaveGangZone(unsigned short, unsigned short)':
CCallbackManager.cpp:(.text+0x2e2): undefined reference to `__stack_chk_fail_local'
CCallbackManager.o: In function `CCallbackManager::OnPlayerEnterPlayerGangZone(unsigned short, unsigned short)':
CCallbackManager.cpp:(.text+0x3c2): undefined reference to `__stack_chk_fail_local'
CCallbackManager.o: In function `CCallbackManager::OnPlayerLeavePlayerGangZone(unsigned short, unsigned short)':
CCallbackManager.cpp:(.text+0x4a2): undefined reference to `__stack_chk_fail_local'
CCallbackManager.o: In function `CCallbackManager::OnPlayerPauseStateChange(unsigned short, bool)':
CCallbackManager.cpp:(.text+0x582): undefined reference to `__stack_chk_fail_local'
CCallbackManager.o:CCallbackManager.cpp:(.text+0x679): more undefined references to `__stack_chk_fail_local' follow
collect2: error: ld returned 1 exit status
makefile:22: recipe for target 'YSF' failed
make: *** [YSF] Error 1
```

*(GCC 4.9.2 @ Kubuntu Vivid 15.04)*

I tested it and it builds and gets loaded by the server without issues.
