### PR TITLE
Standartize CVehicleSyncData quaternions variables

### DIFF
--- a/src/CPlayerData.cpp
+++ b/src/CPlayerData.cpp
@@ -429,7 +429,7 @@ void RebuildSyncData(RakNet::BitStream *bsSync, WORD toplayerid)
 			WORD keys = p->vehicleSyncData.wKeys &= ~pPlayerData[playerid]->dwDisabledKeys;
 			bsSync->Write(keys);
 			
-			bsSync->WriteNormQuat(p->vehicleSyncData.fQuaternionAngle, p->vehicleSyncData.vecQuaternion.fX, p->vehicleSyncData.vecQuaternion.fY, p->vehicleSyncData.vecQuaternion.fZ);
+			bsSync->WriteNormQuat(p->vehicleSyncData.fQuaternion[0], p->vehicleSyncData.fQuaternion[1], p->vehicleSyncData.fQuaternion[2], p->vehicleSyncData.fQuaternion[0]);
 			bsSync->Write((char*)&p->vehicleSyncData.vecPosition, sizeof(CVector));
 			bsSync->WriteVector(p->vehicleSyncData.vecVelocity.fX, p->vehicleSyncData.vecVelocity.fY, p->vehicleSyncData.vecVelocity.fZ);
 			bsSync->Write((WORD)p->vehicleSyncData.fHealth);

--- a/src/Structs.h
+++ b/src/Structs.h
@@ -40,7 +40,7 @@
 #include <map>
 
 #include <raknet/BitStream.h>
-#include <sampgdk/sampgdk.h>
+//#include <sampgdk/sampgdk.h>
 
 class CGangZonePool;
 
@@ -129,8 +129,7 @@ struct CVehicleSyncData
 	WORD			wUDAnalog;				// 0x0021 - 0x0023
 	WORD			wLRAnalog;				// 0x0023 - 0x0025
 	WORD			wKeys;					// 0x0025 - 0x0027
-	float			fQuaternionAngle;		// 0x0027 - 0x002B
-	CVector			vecQuaternion;			// 0x002B - 0x0037
+	float			fQuaternion[4];			// 0x0027 - 0x0037
 	CVector			vecPosition;			// 0x0037 - 0x0043
 	CVector			vecVelocity;			// 0x0043 - 0x004F
 	float			fHealth;				// 0x004F - 0x0053

--- a/src/Structs.h
+++ b/src/Structs.h
@@ -40,7 +40,7 @@
 #include <map>
 
 #include <raknet/BitStream.h>
-//#include <sampgdk/sampgdk.h>
+#include <sampgdk/sampgdk.h>
 
 class CGangZonePool;
 


### PR DESCRIPTION
Add fQuaternion array instead of fQuaternionAngle and vecQuaternion. Why? Because [here](https://github.com/kurta999/YSF/blob/YSF_/src/Structs.h#L173) and [here](https://github.com/kurta999/YSF/blob/YSF_/src/Structs.h#L356) we have same code.
Sorry for the line endings shit (i don't know how to fix it).