### PR TITLE
Small fixes

### DIFF
--- a/src/CCallbackManager.cpp
+++ b/src/CCallbackManager.cpp
@@ -5,7 +5,7 @@ std::vector<AMX *> CCallbackManager::m_vecAMX;
 void CCallbackManager::RegisterAMX(AMX *pAMX)
 {
 	// Add gamemode to the first position in vector
-	if (pNetGame && pNetGame->pGameModePool && &pNetGame->pGameModePool->m_amx == pAMX)
+	if (pNetGame && pNetGame->pGameModePool && &pNetGame->pGameModePool->amx == pAMX)
 	{
 		std::vector<AMX*>::iterator it = m_vecAMX.begin();
 		m_vecAMX.insert(it, pAMX);

--- a/src/CPlayerData.cpp
+++ b/src/CPlayerData.cpp
@@ -429,7 +429,7 @@ void RebuildSyncData(RakNet::BitStream *bsSync, WORD toplayerid)
 			WORD keys = p->vehicleSyncData.wKeys &= ~pPlayerData[playerid]->dwDisabledKeys;
 			bsSync->Write(keys);
 			
-			bsSync->WriteNormQuat(p->vehicleSyncData.fQuaternionAngle, p->vehicleSyncData.vecQuaternion.fX, p->vehicleSyncData.vecQuaternion.fY, p->vehicleSyncData.vecQuaternion.fZ);
+			bsSync->WriteNormQuat(p->vehicleSyncData.fQuaternion[0], p->vehicleSyncData.fQuaternion[1], p->vehicleSyncData.fQuaternion[2], p->vehicleSyncData.fQuaternion[3]);
 			bsSync->Write((char*)&p->vehicleSyncData.vecPosition, sizeof(CVector));
 			bsSync->WriteVector(p->vehicleSyncData.vecVelocity.fX, p->vehicleSyncData.vecVelocity.fY, p->vehicleSyncData.vecVelocity.fZ);
 			bsSync->Write((WORD)p->vehicleSyncData.fHealth);

--- a/src/Structs.h
+++ b/src/Structs.h
@@ -129,8 +129,7 @@ struct CVehicleSyncData
 	WORD			wUDAnalog;				// 0x0021 - 0x0023
 	WORD			wLRAnalog;				// 0x0023 - 0x0025
 	WORD			wKeys;					// 0x0025 - 0x0027
-	float			fQuaternionAngle;		// 0x0027 - 0x002B
-	CVector			vecQuaternion;			// 0x002B - 0x0037
+	float			fQuaternion[4];			// 0x0027 - 0x0037x
 	CVector			vecPosition;			// 0x0037 - 0x0043
 	CVector			vecVelocity;			// 0x0043 - 0x004F
 	float			fHealth;				// 0x004F - 0x0053

--- a/src/Structs.h
+++ b/src/Structs.h
@@ -113,8 +113,8 @@ struct CAimSyncData
 	CVector			vecFront;				// 1 - 13
 	CVector			vecPosition;			// 13 - 25
 	float			fZAim;					// 25 - 29
-	BYTE			byteWeaponState : 6;	// 29
-	BYTE			byteCameraZoom : 2;		// 29
+	BYTE			byteCameraZoom : 6;		// 29
+	BYTE			byteWeaponState : 2;	// 29
 	BYTE			unk;					// 30 - 31
 	WORD			wCameraObject;			// 31 - 33
 	WORD			wCameraVehicle;			// 33 - 35


### PR DESCRIPTION
- Compilation fix after this changes: https://github.com/kurta999/YSF/commit/889357b6c1a69962811309515c6928dfcd377106#diff-59373ab86b6104537f85dbb498edf270L710
- Standartize quaternion CVehicleSyncData. Because [here](https://github.com/kurta999/YSF/blob/YSF_/src/Structs.h#L173) and [here](https://github.com/kurta999/YSF/blob/YSF_/src/Structs.h#L356) we have same code.
- Fix for CAimSyncData byteWeaponState and byteCameraZoom (right declare from old sa-mp sources (tested on FCNPC)).