### PR TITLE
Fixed compiling errors with Debug mode build

### DIFF
--- a/src/main.h
+++ b/src/main.h
@@ -33,6 +33,9 @@
 
 #ifdef _WIN32
 	#define WIN32_LEAN_AND_MEAN
+	#ifndef PSAPI_VERSION
+	#define PSAPI_VERSION 2
+	#endif
 	#define SLEEP(x) { Sleep(x); }
 	#define OS_NAME "Windows"
 


### PR DESCRIPTION
There is an error on compiling with Debug mode (I tried in VS2015 Update1):

1>Utils.obj : error LNK2019: unresolved external symbol _GetModuleInformation@16 referenced in function "unsigned long __cdecl FindPattern(char *,char *)" (?FindPattern@@YAKPAD0@Z)