### PR TITLE
Add OnClientCheckResponse calling for gamemodes

### DIFF
--- a/src/CCallbackManager.cpp
+++ b/src/CCallbackManager.cpp
@@ -329,3 +329,20 @@ void CCallbackManager::OnPlayerClientGameInit(WORD playerid, bool* usecjwalk, bo
 		}
 	}
 }
+
+void CCallbackManager::OnClientCheckResponse(WORD playerid, BYTE type, DWORD arg, BYTE response)
+{
+	int idx = -1;
+	cell ret = 1;
+	for (std::vector<AMX*>::const_iterator iter = m_vecAMX.begin(); iter != m_vecAMX.end(); ++iter) {
+		if (!amx_FindPublic(*iter, "OnClientCheckResponse", &idx)) {
+			amx_Push(*iter, static_cast<cell>(response));
+			amx_Push(*iter, static_cast<cell>(arg));
+			amx_Push(*iter, static_cast<cell>(type));
+			amx_Push(*iter, static_cast<cell>(playerid));
+
+			amx_Exec(*iter, &ret, idx);
+			if (ret) break;
+		}
+	}
+}

--- a/src/CCallbackManager.h
+++ b/src/CCallbackManager.h
@@ -28,6 +28,7 @@ public:
 	static void	OnVehicleSpawn(WORD vehicleid);
 	static void	OnPlayerPickedUpPickup(WORD playerid, WORD pickupid);
 	static void	OnPlayerPickedUpPlayerPickup(WORD playerid, WORD pickupid);
+	static void	OnClientCheckResponse(WORD playerid, WORD pickupid);
 
 
 	static std::vector<AMX *>		m_vecAMX;

--- a/src/RPCs.cpp
+++ b/src/RPCs.cpp
@@ -29,6 +29,7 @@ int RPC_ScrApplyAnimation = 0x56;
 int RPC_ClientMessage = 0x5D;
 int RPC_ScrDisplayGameText = 0x49;
 int RPC_Chat = 0x65;
+int RPC_ClientCheck = 103;
 
 int RPC_UpdateScoresPingsIPs = 0x9B;
 int RPC_PickedUpPickup = 0x83;
@@ -212,6 +213,20 @@ void PickedUpPickup(RPCParameters* rpcParams)
 #endif
 }
 
+void ClientCheck(RPCParameters* rpcParams)
+{
+	WORD playerid = static_cast<WORD>(pRakServer->GetIndexFromPlayerID(rpcParams->sender));
+	DWORD arg;
+	BYTE type, response;
+
+	RakNet::BitStream bsData(rpcParams->input, rpcParams->numberOfBitsOfData / 8, false);
+	bsData.Read(type);
+	bsData.Read(arg);
+	bsData.Read(response);
+
+	CCallbackManager::OnClientCheckResponse(playerid, type, arg, response);
+}
+
 void InitRPCs()
 {
 	pRakServer->UnregisterAsRemoteProcedureCall(&RPC_UpdateScoresPingsIPs);
@@ -225,4 +240,7 @@ void InitRPCs()
 
 	pRakServer->UnregisterAsRemoteProcedureCall(&RPC_PickedUpPickup);
 	pRakServer->RegisterAsRemoteProcedureCall(&RPC_PickedUpPickup, PickedUpPickup);
+
+	pRakServer->UnregisterAsRemoteProcedureCall(&RPC_ClientCheck);
+	pRakServer->RegisterAsRemoteProcedureCall(&RPC_ClientCheck, ClientCheck);
 }

--- a/src/RPCs.h
+++ b/src/RPCs.h
@@ -57,6 +57,7 @@ extern int RPC_ScrApplyAnimation;
 extern int RPC_ClientMessage;
 extern int RPC_ScrDisplayGameText;
 extern int RPC_Chat;
+extern int RPC_ClientCheck;
 
 extern int RPC_UpdateScoresPingsIPs;
 extern int RPC_PickedUpPickup;


### PR DESCRIPTION
By default OnClientCheckResponse is calling only for filterscripts. This PR fixes this.