### PR TITLE
fixed from PVS-Studio

### DIFF
--- a/src/CScriptParams.h
+++ b/src/CScriptParams.h
@@ -212,7 +212,8 @@ template <> inline void CScriptParams::ReadInternal(std::string *result)
 		result->append(temp);
 	}
 	
-	SAFE_DELETE(temp);
+	delete[] temp;
+	temp = NULL;
 }
 
 

--- a/src/CServer.cpp
+++ b/src/CServer.cpp
@@ -835,11 +835,11 @@ char* CServer::GetNPCCommandLine(WORD npcid)
 	hr = CoInitializeEx(0, COINIT_MULTITHREADED);
 	hr = CoInitializeSecurity(NULL, -1, NULL, NULL, RPC_C_AUTHN_LEVEL_DEFAULT, RPC_C_IMP_LEVEL_IMPERSONATE, NULL, EOAC_NONE, NULL);
 	hr = CoCreateInstance(CLSID_WbemLocator, 0, CLSCTX_INPROC_SERVER, IID_IWbemLocator, (LPVOID *)&WbemLocator);
-	hr = WbemLocator->ConnectServer(L"ROOT\\CIMV2", NULL, NULL, NULL, 0, NULL, NULL, &WbemServices);
+	hr = WbemLocator->ConnectServer(SysAllocString(L"ROOT\\CIMV2"), NULL, NULL, NULL, 0, NULL, NULL, &WbemServices);
 
 	std::ostringstream query;
 	query << "SELECT CommandLine FROM Win32_Process WHERE ProcessId=" << pid;
-	hr = WbemServices->ExecQuery(L"WQL", bstr_t(query.str().c_str()), WBEM_FLAG_FORWARD_ONLY, NULL, &EnumWbem);
+	hr = WbemServices->ExecQuery(SysAllocString(L"WQL"), bstr_t(query.str().c_str()), WBEM_FLAG_FORWARD_ONLY, NULL, &EnumWbem);
 
 	if (EnumWbem == NULL) return 0;
 
@@ -906,11 +906,11 @@ int CServer::FindNPCProcessID(WORD npcid)
 	hr = CoInitializeEx(0, COINIT_MULTITHREADED);
 	hr = CoInitializeSecurity(NULL, -1, NULL, NULL, RPC_C_AUTHN_LEVEL_DEFAULT, RPC_C_IMP_LEVEL_IMPERSONATE, NULL, EOAC_NONE, NULL);
 	hr = CoCreateInstance(CLSID_WbemLocator, 0, CLSCTX_INPROC_SERVER, IID_IWbemLocator, (LPVOID *)&WbemLocator);
-	hr = WbemLocator->ConnectServer(L"ROOT\\CIMV2", NULL, NULL, NULL, 0, NULL, NULL, &WbemServices);
+	hr = WbemLocator->ConnectServer(SysAllocString(L"ROOT\\CIMV2"), NULL, NULL, NULL, 0, NULL, NULL, &WbemServices);
 
 	std::ostringstream query;
 	query << "SELECT ProcessId, CommandLine FROM Win32_Process WHERE ParentProcessId=" << cpid;
-	hr = WbemServices->ExecQuery(L"WQL", bstr_t(query.str().c_str()), WBEM_FLAG_FORWARD_ONLY, NULL, &EnumWbem);
+	hr = WbemServices->ExecQuery(SysAllocString(L"WQL"), bstr_t(query.str().c_str()), WBEM_FLAG_FORWARD_ONLY, NULL, &EnumWbem);
 
 
 	if (EnumWbem == NULL) return 0;

--- a/src/RPCs.cpp
+++ b/src/RPCs.cpp
@@ -127,7 +127,7 @@ void InitRPCs()
 
 			if (pNetGame->iGameState != GAMESTATE_RUNNING) return;
 
-			WORD playerid = playerid = static_cast<WORD>(CSAMPFunctions::GetIndexFromPlayerID(rpcParams->sender));
+			WORD playerid = static_cast<WORD>(CSAMPFunctions::GetIndexFromPlayerID(rpcParams->sender));
 			if (!IsPlayerConnected(playerid)) return;
 			CPlayer	*pPlayer = pNetGame->pPlayerPool->pPlayer[playerid];
 

--- a/src/natives/server.cpp
+++ b/src/natives/server.cpp
@@ -350,6 +350,7 @@ AMX_DECLARE_NATIVE(Natives::CallFunctionInScript)
 	if ((params[0] / sizeof(cell) - (param_offset - 1)) != num_params)
 	{
 		logprintf("parameter count does not match format specifier length %d - %d", num_params, (params[0] / sizeof(cell) - (param_offset - 1)));
+		delete[] format;
 		return 0;
 	}
 


### PR DESCRIPTION
I'm a member of the Pinguem.ru competition on finding errors in open source projects. A bug, found using PVS-Studio. Warnings:

[V611](https://www.viva64.com/en/w/v611/) The memory was allocated using 'new T[]' operator but was released using the 'delete' operator. Consider inspecting this code. It's probably better to use 'delete [] temp;'. cscriptparams.h 215
[V700](https://www.viva64.com/en/w/v700/) Consider inspecting the 'T foo = foo = ...' expression. It is odd that variable is initialized through itself. rpcs.cpp 130
[V745](https://www.viva64.com/en/w/v745/) A 'wchar_t *' type string is incorrectly converted to 'BSTR' type string. Consider using 'SysAllocString' function. cserver.cpp 838, 842, 909, 913
[V773](https://www.viva64.com/en/w/v773/) The function was exited without releasing the 'format' pointer. A memory leak is possible. server.cpp 353